### PR TITLE
fix: 更新百度翻译API地址

### DIFF
--- a/kiwi-cli/package.json
+++ b/kiwi-cli/package.json
@@ -5,7 +5,8 @@
   "main": "dist/index.js",
   "scripts": {
     "dev": "tsc --watch",
-    "prepublish": "tsc"
+    "prepublish": "tsc",
+    "postinstall": "patch-package"
   },
   "repository": {
     "type": "git",
@@ -45,6 +46,7 @@
     "inquirer": "^5.2.0",
     "lodash": "^4.17.11",
     "ora": "^3.0.0",
+    "patch-package": "^6.5.1",
     "pinyin-pro": "^3.3.1",
     "prettier": "^1.16.4",
     "randomstring": "^1.1.5",

--- a/kiwi-cli/patches/baidu-translate+1.3.0.patch
+++ b/kiwi-cli/patches/baidu-translate+1.3.0.patch
@@ -1,0 +1,13 @@
+diff --git a/node_modules/baidu-translate/index.js b/node_modules/baidu-translate/index.js
+index 4d0e427..521c502 100644
+--- a/node_modules/baidu-translate/index.js
++++ b/node_modules/baidu-translate/index.js
+@@ -24,7 +24,7 @@ function baiduTranslate(appid, secret, to = "en", from = "auto", dict = 1, tts =
+                 tts
+             };
+             request.post({
+-                url: "http://api.fanyi.baidu.com/api/trans/vip/translate",
++                url: "https://fanyi-api.baidu.com/api/trans/vip/translate",
+                 form: querystring.stringify(postData)
+             }, function (err, httpResponse, body) {
+                 if (err) {


### PR DESCRIPTION
百度翻译API地址更换为 `https://fanyi-api.baidu.com/api/trans/vip/translate`

[百度翻译文档链接](https://fanyi-api.baidu.com/product/113)